### PR TITLE
Update index.rst

### DIFF
--- a/components/alarm_control_panel/index.rst
+++ b/components/alarm_control_panel/index.rst
@@ -183,7 +183,7 @@ From :ref:`lambdas <config-lambda>`, you can call the following methods:
 
     id(acp1).arm_away();
     id(acp1).arm_home();
-    id(acp1).disarm("1234");
+    id(acp1).disarm(std::string("1234"));
 
 
 Platforms


### PR DESCRIPTION
The code parameter is an optional. Without "std::string("1234")" compilation fails.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
